### PR TITLE
feat!: support concurrent calls

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -3,13 +3,47 @@
     "main"
   ],
   "plugins": [
-    "@semantic-release/commit-analyzer",
-    "@semantic-release/release-notes-generator",
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        "preset": "conventionalcommits",
+        "releaseRules": [
+          {
+            "type": "docs",
+            "scope": "README",
+            "release": "patch"
+          },
+          {
+            "type": "refactor",
+            "release": "patch"
+          },
+          {
+            "type": "style",
+            "release": "patch"
+          }
+        ],
+        "parserOpts": {
+          "noteKeywords": [
+            "BREAKING CHANGE",
+            "BREAKING CHANGES"
+          ]
+        }
+      }
+    ],
+    [
+      "@semantic-release/release-notes-generator",
+      {
+        "preset": "conventionalcommits"
+      }
+    ],
     "@semantic-release/changelog",
     "@semantic-release/npm",
-    ["@semantic-release/github", {
-      "assets": []
-    }],
+    [
+      "@semantic-release/github",
+      {
+        "assets": []
+      }
+    ],
     [
       "@semantic-release/git",
       {

--- a/README.md
+++ b/README.md
@@ -40,19 +40,26 @@ const logger = new Quill()
 // Create an instance of Odysseus
 const odysseus = new Odysseus(config, logger)
 
+// Initialize odysseus
+await odysseus.init()
+
 async function fetchContent(url: string, delay: number) {
   try {
     const content = await odysseus.getContent(url, delay)
     console.log(content)
   } catch (error) {
     console.error('Failed to fetch content:', error)
-  } finally {
-    // Close the browser
-    await odysseus.close()
   }
 }
 
-await fetchContent('https://www.tiktok.com/explore', 6_000)
+// Each fetchContent opens a new tab so can be run concurrently
+await Promise.all([
+  fetchContent('https://www.tiktok.com/explore', 6_000),
+  fetchContent('https://www.tiktok.com/explore', 6_000),
+  fetchContent('https://www.tiktok.com/explore', 6_000),
+])
+
+await odysseus.close()
 ```
 
 ## API Documentation

--- a/docs/API.md
+++ b/docs/API.md
@@ -18,6 +18,10 @@ Creates an instance of the `Odysseus` class.
 
 ## Public Methods
 
+### `async init(): Promise<void>`
+
+Initializes Odysseus.
+
 ### `async close(): Promise<void>`
 
 Closes the browser if it is open.

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "@semantic-release/git": "^10.0.1",
         "@semantic-release/npm": "^11.0.0",
         "@types/jest": "^29.4.0",
+        "conventional-changelog-conventionalcommits": "^8.0.0",
         "eslint": "^8.52.0",
         "husky": "^8.0.3",
         "jest": "^29.7.0",
@@ -747,6 +748,18 @@
       },
       "engines": {
         "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/config-conventional/node_modules/conventional-changelog-conventionalcommits": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-7.0.2.tgz",
+      "integrity": "sha512-NKXYmMR/Hr1DevQegFB4MwfM5Vv0m4UIxKZTTYuD98lpTknaZlSRrDOG4X7wIXpGkfsYxZTghUN+Qq+T0YQI7w==",
+      "dev": true,
+      "dependencies": {
+        "compare-func": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/@commitlint/config-validator": {
@@ -3606,15 +3619,15 @@
       }
     },
     "node_modules/conventional-changelog-conventionalcommits": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-7.0.2.tgz",
-      "integrity": "sha512-NKXYmMR/Hr1DevQegFB4MwfM5Vv0m4UIxKZTTYuD98lpTknaZlSRrDOG4X7wIXpGkfsYxZTghUN+Qq+T0YQI7w==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-8.0.0.tgz",
+      "integrity": "sha512-eOvlTO6OcySPyyyk8pKz2dP4jjElYunj9hn9/s0OB+gapTO8zwS9UQWrZ1pmF2hFs3vw1xhonOLGcGjy/zgsuA==",
       "dev": true,
       "dependencies": {
         "compare-func": "^2.0.0"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       }
     },
     "node_modules/conventional-changelog-writer": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@semantic-release/git": "^10.0.1",
     "@semantic-release/npm": "^11.0.0",
     "@types/jest": "^29.4.0",
+    "conventional-changelog-conventionalcommits": "^8.0.0",
     "eslint": "^8.52.0",
     "husky": "^8.0.3",
     "jest": "^29.7.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build": "./node_modules/typescript/bin/tsc -p ./tsconfig.build.json",
     "lint": "eslint . --ext .js,.ts",
     "lint:fix": "npm run lint -- --fix",
-    "test": "NODE_OPTIONS=--experimental-vm-modules jest --coverage --detectOpenHandles --forceExit",
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest --coverage --detectOpenHandles --forceExit --runInBand",
     "dev": "ts-node src/index.ts",
     "prepare": "husky install",
     "postinstall": "npx playwright install chromium",


### PR DESCRIPTION
Supports concurrent calls so that multiple pages can be fetched concurrently with `Promise.all()`

```ts
await Promise.all([
  odysseus.getContent('https://www.tiktok.com/explore', 6_000),
  odysseus.getContent('https://www.tiktok.com/explore', 6_000),
  odysseus.getContent('https://www.tiktok.com/explore', 6_000),
])
```